### PR TITLE
Changes to address issue with incorrect number of encoder units being…

### DIFF
--- a/PowerUp/src/Commands/AutonomousDrive.cpp
+++ b/PowerUp/src/Commands/AutonomousDrive.cpp
@@ -11,8 +11,8 @@ AutonomousDrive::AutonomousDrive(const RobotNavigation::RobotTrajectory& path) :
 void AutonomousDrive::Initialize()
 {
 	Robot::driveTrain->SetSafetyEnabled(false);
-	Robot::driveTrain->InitializeMotionProfile(m_path.m_left.m_generator, m_path.m_right.m_generator);
 	Robot::driveTrain->EnableVoltageCompensation(true);
+	Robot::driveTrain->InitializeMotionProfile(m_path.m_left.m_generator, m_path.m_right.m_generator);
 }
 
 bool AutonomousDrive::IsFinished()

--- a/PowerUp/src/Subsystems/DriveTrain.h
+++ b/PowerUp/src/Subsystems/DriveTrain.h
@@ -41,7 +41,7 @@ public:
 	constexpr static double lowGgearRatio = 15.0 / 1.0;
 	constexpr static double lowGgearEncoderRatio = lowGgearRatio * (12.0 / 30.0);
 	constexpr static double sensorUnitsPerRev = 128 * 4; // The TalonSRX counts 4 edges per encoder count, the quadrature encoder has 256 counts per revolution
-	constexpr static double nativeUnitsPerMeterLowGear = 1 / wheelCircumference * lowGgearEncoderRatio * sensorUnitsPerRev; // Approx. 19249 for 256 count per rev, 9624 fir 128 count per rev
+	constexpr static double nativeUnitsPerMeterLowGear = 1 / wheelCircumference * lowGgearEncoderRatio * sensorUnitsPerRev; // Approx. 19249 for 256 count per rev, 9624 for 128 count per rev
 
     constexpr static double maxNativeUnitsPer100ms = 2950 * sensorUnitsPerRev / 1024; // measured at 11v on comp bot with 1024 native units per rev
     constexpr static double maxVelocityLowGear = 10 * maxNativeUnitsPer100ms / nativeUnitsPerMeterLowGear; // Approx. 1.51 Meters per second

--- a/PowerUp/src/Subsystems/DriveTrain.h
+++ b/PowerUp/src/Subsystems/DriveTrain.h
@@ -41,10 +41,10 @@ public:
 	constexpr static double lowGgearRatio = 15.0 / 1.0;
 	constexpr static double lowGgearEncoderRatio = lowGgearRatio * (12.0 / 30.0);
 	constexpr static double sensorUnitsPerRev = 128 * 4; // The TalonSRX counts 4 edges per encoder count, the quadrature encoder has 256 counts per revolution
-	constexpr static double nativeUnitsPerMeterLowGear = 1 / wheelCircumference * lowGgearEncoderRatio * sensorUnitsPerRev; // Approx. 19249
+	constexpr static double nativeUnitsPerMeterLowGear = 1 / wheelCircumference * lowGgearEncoderRatio * sensorUnitsPerRev; // Approx. 19249 for 256 count per rev, 9624 fir 128 count per rev
 
-	constexpr static double maxNativeUnitsPer100ms = 2950; // measured at 11v on comp bot
-	constexpr static double maxVelocityLowGear = 10 * maxNativeUnitsPer100ms / nativeUnitsPerMeterLowGear; // Approx. 1.51 Meters per second
+    constexpr static double maxNativeUnitsPer100ms = 2950 * sensorUnitsPerRev / 1024; // measured at 11v on comp bot with 1024 native units per rev
+    constexpr static double maxVelocityLowGear = 10 * maxNativeUnitsPer100ms / nativeUnitsPerMeterLowGear; // Approx. 1.51 Meters per second
 	constexpr static double feedForwardGain = 1023 / maxNativeUnitsPer100ms;
 
 private:

--- a/PowerUp/src/Utilities/RobotNavigation.h
+++ b/PowerUp/src/Utilities/RobotNavigation.h
@@ -28,10 +28,12 @@ public:
 	static RobotTrajectory CreateProfile(const double distance, const double startVelocity, const double finalVelocity, const double angleDegrees);
 
 private:
+	static double CalculateDuration(const double distance, const double startVelocity, const double finalVelocity);
+
 	RobotTrajectory CreatePathFromStartToSwitch() const;
 	RobotTrajectory CreatePathFromStartToScale() const;
 	constexpr static double wheelTrack = 0.64;
-	constexpr static double maxVelocity = DriveTrain::maxVelocityLowGear * 0.8;
+	constexpr static double maxSpeed = DriveTrain::maxVelocityLowGear * 0.8;
 	constexpr static double timeToMaxSpeed = 1.0;
 	const FieldOrientation m_fieldOrientation;
 };


### PR DESCRIPTION
Renamed `maxVelocity` to `maxSpeed`
Fixed `maxSpeed` to use the correct encoder units
Modified `RobotNavigation::CreateProfile` when creating a profile when both the starting and final velocities are 0 and a rotation is applied to ensure that generated profile does not exceed the maximum speed or jerk